### PR TITLE
feat: 添加港股市场支持

### DIFF
--- a/AIShareTxt/__init__.py
+++ b/AIShareTxt/__init__.py
@@ -5,7 +5,7 @@ AIShareTxt - 股票技术指标分析工具包
 AI集成分析和报告生成功能。
 """
 
-__version__ = "2026.04.27.78"
+__version__ = "2026.05.01.79"
 __author__ = "AIShareTxt Team"
 
 # 导入核心类

--- a/AIShareTxt/core/config.py
+++ b/AIShareTxt/core/config.py
@@ -216,6 +216,28 @@ class IndicatorConfig:
         '0': 'sz',  # 深圳市场
         '3': 'sz'   # 深圳市场（创业板）
     }
+
+    # 市场配置
+    MARKET_CONFIGS = {
+        'CN': {
+            'name': 'A股',
+            'description': '中国大陆证券市场'
+        },
+        'HK': {
+            'name': '港股',
+            'description': '香港联合交易所',
+            'market_map': {},
+            'calendar': 'HKEX',
+            'currency': 'HKD',
+            'currency_symbol': 'HK$',
+        }
+    }
+
+    # 股票代码模式（正则）
+    STOCK_CODE_PATTERNS = {
+        'CN': r'^[036]\d{5}$',     # 6位数字，0/3/6开头
+        'HK': r'^0\d{4}$'           # 5位数字，0开头
+    }
     
     # 数据源配置
     DATA_SOURCE_CONFIG = {
@@ -359,6 +381,26 @@ class IndicatorConfig:
     LOG_FILE_PATH = 'logs/'
     LOG_MAX_SIZE = 10 * 1024 * 1024  # 10MB
     LOG_BACKUP_COUNT = 5
+
+    @staticmethod
+    def identify_market(stock_code: str) -> str:
+        """根据股票代码识别市场 ('CN', 'HK', 或 'UNKNOWN')"""
+        import re
+        if not stock_code or not isinstance(stock_code, str):
+            return 'UNKNOWN'
+        stock_code = stock_code.strip()
+        # 港股：5位数字，0开头（先匹配，避免与A股冲突）
+        if re.match(IndicatorConfig.STOCK_CODE_PATTERNS['HK'], stock_code):
+            return 'HK'
+        # A股：6位数字，0/3/6开头
+        if re.match(IndicatorConfig.STOCK_CODE_PATTERNS['CN'], stock_code):
+            return 'CN'
+        return 'UNKNOWN'
+
+    @staticmethod
+    def get_market_config(market: str) -> dict:
+        """获取指定市场的配置"""
+        return IndicatorConfig.MARKET_CONFIGS.get(market, IndicatorConfig.MARKET_CONFIGS['CN'])
 
 
 # 向后兼容的别名

--- a/AIShareTxt/indicators/data_fetcher.py
+++ b/AIShareTxt/indicators/data_fetcher.py
@@ -22,7 +22,13 @@ class StockDataFetcher:
     def __init__(self):
         self.config = Config()
         self.logger = LoggerManager.get_logger('data_fetcher')
-        self.sse_calendar = mcal.get_calendar('SSE')
+
+        # 初始化多市场日历
+        self.calendars = {
+            'SSE': mcal.get_calendar('SSE'),
+            'HKEX': mcal.get_calendar('HKEX'),
+        }
+        self.sse_calendar = self.calendars['SSE']
 
         # 初始化数据源
         self._akshare = AkshareDataSource()
@@ -45,12 +51,16 @@ class StockDataFetcher:
     # ==================== 公开接口 ====================
 
     def fetch_stock_data(self, stock_code: str, period: Optional[str] = None,
-                         adjust: Optional[str] = None, start_date: Optional[str] = None) -> Optional[pd.DataFrame]:
+                         adjust: Optional[str] = None, start_date: Optional[str] = None,
+                         market: Optional[str] = None) -> Optional[pd.DataFrame]:
         """
-        获取股票历史价格数据
+        获取股票历史价格数据（支持多市场）
 
         根据配置选择主数据源，失败后 fallback 到 akshare
         """
+        if market is None:
+            market = self.config.identify_market(stock_code)
+
         if period is None:
             period = self.config.DATA_CONFIG['default_period']
         if adjust is None:
@@ -60,16 +70,19 @@ class StockDataFetcher:
             default_start = datetime.now() - timedelta(days=months_back * 30)
             start_date = default_start.strftime('%Y%m%d')
 
-        # 主数据源
-        raw_data = self._primary.fetch_stock_data(stock_code, period, start_date, adjust)
-        self._used_source = self._primary.name
-
-        # fallback 到 akshare
-        if (raw_data is None or (isinstance(raw_data, pd.DataFrame) and len(raw_data) == 0)):
-            if self._primary is not self._akshare:
-                self.logger.info("主数据源失败，fallback 到 akshare")
-                raw_data = self._akshare.fetch_stock_data(stock_code, period, start_date, adjust)
-                self._used_source = 'akshare'
+        if market == 'HK':
+            raw_data = self._akshare.fetch_hk_stock_data(stock_code, start_date, cast(str, adjust))
+        elif market == 'CN':
+            raw_data = self._primary.fetch_stock_data(stock_code, period, start_date, adjust)
+            self._used_source = self._primary.name
+            if (raw_data is None or (isinstance(raw_data, pd.DataFrame) and len(raw_data) == 0)):
+                if self._primary is not self._akshare:
+                    self.logger.info("主数据源失败，fallback 到 akshare")
+                    raw_data = self._akshare.fetch_stock_data(stock_code, period, start_date, adjust)
+                    self._used_source = 'akshare'
+        else:
+            self.logger.error(f"不支持的市场类型: {market}")
+            return None
 
         if raw_data is None or (isinstance(raw_data, pd.DataFrame) and len(raw_data) == 0):
             self.logger.error(f"所有数据源均获取失败：{stock_code}")
@@ -77,8 +90,14 @@ class StockDataFetcher:
 
         return self._process_stock_data(raw_data, stock_code)
 
-    def get_fund_flow_data(self, stock_code, target_date=None):
+    def get_fund_flow_data(self, stock_code, target_date=None, market: Optional[str] = None):
         """获取主力资金流数据，含日期一致性校验"""
+        if market is None:
+            market = self.config.identify_market(stock_code)
+        if market == 'HK':
+            self.logger.info("港股不支持主力资金流数据")
+            return {}
+
         data = self._primary.get_fund_flow_data(stock_code, target_date)
 
         # 校验返回数据的日期是否与请求日期一致
@@ -97,8 +116,13 @@ class StockDataFetcher:
 
         return data
 
-    def get_stock_basic_info(self, stock_code):
+    def get_stock_basic_info(self, stock_code, market: Optional[str] = None):
         """获取股票基本信息"""
+        if market is None:
+            market = self.config.identify_market(stock_code)
+        if market == 'HK':
+            return self._akshare.get_hk_stock_basic_info(stock_code)
+
         info = self._primary.get_stock_basic_info(stock_code)
 
         if (not info or info.get('股票简称') == '未知') and self._primary is not self._akshare:

--- a/AIShareTxt/indicators/data_sources/akshare_source.py
+++ b/AIShareTxt/indicators/data_sources/akshare_source.py
@@ -498,3 +498,102 @@ class AkshareDataSource(BaseDataSource):
             '市盈率': "未知",
             '市净率': "未知"
         }
+
+    # ==================== 港股数据 ====================
+
+    def fetch_hk_stock_data(self, stock_code: str, start_date: str, adjust: str) -> Optional[pd.DataFrame]:
+        """获取港股历史数据（东方财富 → stock_hk_daily fallback）"""
+        raw_data = self._fetch_from_hk_hist_em(stock_code, start_date, adjust)
+        if raw_data is None or len(raw_data) == 0:
+            self.logger.error(f"港股数据获取失败：{stock_code}")
+            return None
+        return raw_data
+
+    def _fetch_from_hk_hist_em(self, stock_code: str, start_date: str, adjust: str) -> Optional[pd.DataFrame]:
+        """从东方财富获取港股历史数据"""
+        try:
+            self.logger.info(f"[港股] 从东方财富获取港股 {stock_code} 的数据（从 {start_date} 开始）...")
+            end_date = datetime.now().strftime('%Y%m%d')
+            raw_data = ak.stock_hk_hist(
+                symbol=stock_code,
+                period='daily',
+                start_date=start_date,
+                end_date=end_date,
+                adjust=adjust
+            )
+            return cast(pd.DataFrame, raw_data)
+        except Exception as e:
+            self.logger.warning(f"[港股] stock_hk_hist获取失败：{str(e)}，尝试备用API...")
+
+        try:
+            self.logger.info(f"[港股] 尝试备用API stock_hk_daily 获取港股 {stock_code} 的数据...")
+            raw_data = ak.stock_hk_daily(symbol=stock_code)
+            return cast(pd.DataFrame, raw_data)
+        except Exception as e:
+            self.logger.warning(f"[港股] stock_hk_daily获取失败：{str(e)}")
+            return None
+
+    def get_hk_stock_basic_info(self, stock_code: str) -> dict:
+        """获取港股基本信息"""
+        info = {'股票代码': stock_code}
+
+        try:
+            df = ak.stock_hk_company_profile_em(symbol=stock_code)
+            if not df.empty:
+                info.update({
+                    '股票简称': df.iloc[0].get('公司名称', '未知'),
+                    '行业': df.iloc[0].get('所属行业', '未知'),
+                })
+                self.logger.info("✓ 港股公司信息获取成功（东方财富 API）")
+        except Exception as e:
+            self.logger.warning(f"[港股] 东方财富港股基本信息失败：{str(e)}")
+
+        if info.get('股票简称') == '未知':
+            try:
+                xq_info = self._get_hk_basic_info_from_xq(stock_code)
+                if xq_info.get('股票简称') != '未知':
+                    info.update(xq_info)
+                    self.logger.info("✓ 港股公司信息获取成功（雪球 API）")
+            except Exception as e:
+                self.logger.warning(f"[港股] 雪球港股基本信息失败：{str(e)}")
+
+        try:
+            df = ak.stock_hk_financial_indicator_em(symbol=stock_code)
+            if not df.empty:
+                info.update({
+                    '总市值': df.iloc[0].get('总市值(港元)', 0),
+                    '市盈率': df.iloc[0].get('市盈率', '未知'),
+                    '市净率': df.iloc[0].get('市净率', '未知'),
+                    '股息率': df.iloc[0].get('股息率TTM(%)', 0),
+                    '每股净资产': df.iloc[0].get('每股净资产(元)', 0),
+                })
+        except Exception as e:
+            self.logger.warning(f"[港股] 财务指标获取失败：{str(e)}")
+
+        return self._format_market_values(info)
+
+    def _get_hk_basic_info_from_xq(self, stock_code: str) -> dict:
+        """从雪球获取港股基本信息"""
+        xq_code = f'HK{stock_code.zfill(5)}'
+        try:
+            df = ak.stock_individual_basic_info_hk_xq(symbol=xq_code)
+            info = {}
+            name = '未知'
+            name_row = df[df['item'] == 'name']
+            if not name_row.empty:
+                val = name_row.iloc[0]['value']
+                if pd.notna(val) and val:
+                    name = val
+            info['股票简称'] = name
+
+            industry = '未知'
+            industry_row = df[df['item'] == 'industry']
+            if not industry_row.empty:
+                val = industry_row.iloc[0]['value']
+                if isinstance(val, dict) and 'name' in val:
+                    industry = val['name']
+            info['行业'] = industry
+            return info
+        except Exception as e:
+            self.logger.warning(f"[港股] 雪球API获取失败：{str(e)}")
+            return {'股票简称': '未知', '行业': '未知'}

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ dev_requires = read_requirements("requirements-dev.txt")
 
 setup(
     name="aishare-txt",
-    version="2026.04.27.78",
+    version="2026.05.01.79",
     author="AIShareTxt Team",
     author_email="chaofanat@gmail.com",
     description="中国股票技术指标文本生成工具包，用于为金融分析相关领域的AI智能体提供上下文服务。",


### PR DESCRIPTION
## Summary
- 新增港股市场配置（HKEX、港币、交易日历等）
- 支持港股数据获取（东方财富API + 备用API）
- 新增股票代码市场自动识别（CN/HK）

## Fixes
修复正则表达式问题：
- CN: `[0-3|6]` → `[036]`，修正字符类中 `|` 被当作字面量
- HK: `^\d{5}$` → `^0\d{4}$`，限制港股代码以 0 开头

## Test plan
- [x] A 股代码识别正常（600000、300001、000001）
- [x] 港股代码识别正常（00700、03690）
- [x] 非法代码被正确拒绝（123456、12345）
- [x] 港股数据获取功能正常